### PR TITLE
First swagger api spec

### DIFF
--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -1,0 +1,172 @@
+swagger: "2.0"
+info:
+  description: >
+    This API aims to improve the transport data accuracy by allowing consumers to suggest patches for different
+    resources.
+  version: "0.1.0"
+  title: "Hermod - the Crowd sourcing API"
+  termsOfService: "http://to-be-defined/terms/"
+  contact:
+    email: "to-be-defined@navitia.io"
+  license:
+    name: "MIT"
+    url: "https://opensource.org/licenses/MIT"
+host: "to-be-defined.io"
+tags:
+- name: "stop_points"
+  description: "Suggesting patches to improve stop point location"
+- name: "status"
+  description: "Verify the API status"
+schemes:
+- "https"
+paths:
+  /nav-1/v1/stop_point_patches:
+    post:
+      tags:
+        - "stop_points"
+      summary: "Suggest a new location for a stop point"
+      description: "Description"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          schema:
+            type: "object"
+            required:
+            - stop_point_id
+            - stop_point_name
+            - stop_point_current_location
+            - route_id
+            properties:
+              stop_point_id:
+                type: "string"
+                description: "Stop point id"
+              stop_point_name:
+                type: "string"
+                description: "Stop point name"
+              stop_point_current_location:
+                $ref: "#/definitions/Coord"
+              stop_point_patched_location:
+                $ref: "#/definitions/Coord"
+              route_id:
+                type: "string"
+                description: "Route id"
+              user_gps_location:
+                $ref: "#/definitions/Coord"
+              user_gps_accuracy:
+                type: "number"
+                format: "float"
+                description: "User GPS accuracy in meters"
+      responses:
+        201:
+          description: "Everything went fine"
+          schema:
+            $ref: "#/definitions/ResourceCreatedResponse"
+        400:
+          description: "Invalid request"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      security:
+      - api_key: []
+  /nav-1/v1/stop_point_patches/gps:
+    post:
+      tags:
+      - "stop_points"
+      summary: "Suggest a new location for a stop point using the given GPS coord / accuracy"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          schema:
+            type: "object"
+            required:
+            - stop_point_id
+            - stop_point_name
+            - stop_point_current_location
+            - route_id
+            - user_gps_location
+            - user_gps_accuracy
+            properties:
+              stop_point_id:
+                type: "string"
+                description: "Stop point id"
+              stop_point_name:
+                type: "string"
+                description: "Stop point name"
+              stop_point_current_location:
+                $ref: "#/definitions/Coord"
+              route_id:
+                type: "string"
+                description: "Route id"
+              user_gps_location:
+                $ref: "#/definitions/Coord"
+              user_gps_accuracy:
+                type: "number"
+                format: "float"
+                description: "User GPS accuracy in meters"
+      responses:
+        201:
+          description: "Everything went fine"
+          schema:
+            $ref: "#/definitions/ResourceCreatedResponse"
+        400:
+          description: "Invalid request"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      security:
+      - api_key: []
+  /status:
+    get:
+      tags:
+      - "status"
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "The API is reachable"
+          schema:
+            type: "object"
+            properties:
+              message:
+                type: "string"
+                example: "The API is up and running !"
+      
+      
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "Authorization"
+    in: "header"
+definitions:
+  Coord:
+    type: "object"
+    description: "Coordinates - WGS84"
+    required: ['lat', 'lon']
+    properties:
+      lat:
+        type: "number"
+        format: "float"
+      lon:
+        type: "number"
+        format: "float"
+  ResourceCreatedResponse:
+    type: "object"
+    properties:
+      message:
+        type: "string"
+        example: "The resource has been successfully created"
+  ErrorResponse:
+    type: "object"
+    properties:
+      error:
+        type: "string"
+        example: "missing_param"
+      message:
+        type: "string"
+        example: "param 'foo_bar' is missing"

--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -18,7 +18,7 @@ tags:
 schemes:
 - "https"
 paths:
-  /nav-1/v1/stop_point_patches:
+  /v1/stop_point_patches:
     post:
       tags:
         - "stop_point_patch"
@@ -33,40 +33,33 @@ paths:
           schema:
             type: "object"
             required:
-            - stop_point_id
-            - stop_point_name
+            - source
+            - stop_point
             - stop_point_current_location
-            - route_id
+            - route
             properties:
-              stop_point_id:
-                type: "string"
-                description: "Stop point id"
-              stop_point_name:
-                type: "string"
-                description: "Stop point name"
+              source:
+                $ref: "#/definitions/Source"
+              stop_point:
+                $ref: "#/definitions/StopPoint"
               stop_point_current_location:
                 $ref: "#/definitions/Coord"
               stop_point_patched_location:
                 $ref: "#/definitions/Coord"
-              route_id:
-                type: "string"
-                description: "Route id"
-              user_gps_location:
-                $ref: "#/definitions/Coord"
-              user_gps_accuracy:
-                type: "number"
-                format: "float"
-                description: "User GPS accuracy in meters"
+              route:
+                $ref: "#/definitions/Route"
+              gps:
+                $ref: "#/definitions/Gps"
       responses:
         201:
           description: "Everything went fine"
         400:
           description: "Invalid request"
           schema:
-            $ref: "#/definitions/ErrorResponse"
+            $ref: "#/definitions/Errors"
       security:
       - api_key: []
-  /nav-1/v1/stop_point_patches/gps:
+  /v1/stop_point_patches/gps:
     post:
       tags:
       - "stop_point_patch"
@@ -81,42 +74,35 @@ paths:
           schema:
             type: "object"
             required:
-            - stop_point_id
-            - stop_point_name
+            - source
+            - stop_point
             - stop_point_current_location
             - route_id
-            - user_gps_location
-            - user_gps_accuracy
+            - gps
             properties:
-              stop_point_id:
-                type: "string"
-                description: "Stop point id"
-              stop_point_name:
-                type: "string"
-                description: "Stop point name"
+              source:
+                $ref: "#/definitions/Source"
+              stop_point:
+                $ref: "#/definitions/StopPoint"
               stop_point_current_location:
                 $ref: "#/definitions/Coord"
               route_id:
                 type: "string"
                 description: "Route id"
-              user_gps_location:
-                $ref: "#/definitions/Coord"
-              user_gps_accuracy:
-                type: "number"
-                format: "float"
-                description: "User GPS accuracy in meters"
+              gps:
+                $ref: "#/definitions/Gps"
       responses:
         201:
           description: "Everything went fine"
         400:
           description: "Invalid request"
           schema:
-            $ref: "#/definitions/ErrorResponse"
+            $ref: "#/definitions/Errors"
       security:
       - api_key: []
-  /status:
+  /v1/status:
     get:
-      summary: "Check if the service is up and running"
+      summary: "Utility endpoint to check if the service is up and running"
       tags:
       - "status"
       produces:
@@ -127,15 +113,52 @@ paths:
           schema:
             type: "object"
             properties:
-              message:
+              status:
                 type: "string"
-                example: "The API is up and running !"
+                enum: ["OK", "KO"]
 securityDefinitions:
   api_key:
     type: "apiKey"
     name: "Authorization"
     in: "header"
 definitions:
+  Source:
+    type: "object"
+    required: ["type", "instance_name"]
+    properties:
+      type:
+        type: "string"
+        enum: ["nav_1", "nav_2"]
+        description: "The navitia version to use"
+      instance_name:
+        type: "string"
+        description: "Stop point name"
+  StopPoint:
+    type: "object"
+    required: ["id", "name"]
+    properties:
+      id:
+        type: "string"
+        description: "Stop point id"
+      name:
+        type: "string"
+        description: "Stop point name"
+  Route:
+    type: "object"
+    required: ["id"]
+    properties:
+      id:
+        type: "string"
+        description: "Route id"
+  Gps:
+    type: "object"
+    properties:
+      location:
+        $ref: '#/definitions/Coord'
+      accuracy:
+        type: "number"
+        format: "float"
+        description: "GPS accuracy (in meters)"
   Coord:
     type: "object"
     description: "Coordinates - WGS84"
@@ -147,13 +170,16 @@ definitions:
       lon:
         type: "number"
         format: "float"
-  ErrorResponse:
-    type: "object"
-    properties:
-      error:
-        type: "string"
-        enum: ["invalid_request"]
-        example: "invalid_request"
-      message:
-        type: "string"
-        example: "param 'foo_bar' is missing"
+  Errors:
+    type: "array"
+    title: "Errors"
+    items:
+      type: "object"
+      properties:
+        error:
+          type: "string"
+          enum: ["invalid_request"]
+          example: "invalid_request"
+        message:
+          type: "string"
+          example: "param 'foo_bar' is missing"

--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -5,13 +5,11 @@ info:
     resources.
   version: "0.1.0"
   title: "Hermod - the Crowd sourcing API"
-  termsOfService: "http://to-be-defined/terms/"
   contact:
     email: "to-be-defined@navitia.io"
   license:
     name: "MIT"
     url: "https://opensource.org/licenses/MIT"
-host: "to-be-defined.io"
 tags:
 - name: "stop_point_patch"
   description: "Suggest patches to improve stop point information"
@@ -62,8 +60,6 @@ paths:
       responses:
         201:
           description: "Everything went fine"
-          schema:
-            $ref: "#/definitions/ResourceCreatedResponse"
         400:
           description: "Invalid request"
           schema:
@@ -112,8 +108,6 @@ paths:
       responses:
         201:
           description: "Everything went fine"
-          schema:
-            $ref: "#/definitions/ResourceCreatedResponse"
         400:
           description: "Invalid request"
           schema:
@@ -145,7 +139,7 @@ definitions:
   Coord:
     type: "object"
     description: "Coordinates - WGS84"
-    required: ['lat', 'lon']
+    required: ["lat", "lon"]
     properties:
       lat:
         type: "number"
@@ -153,18 +147,13 @@ definitions:
       lon:
         type: "number"
         format: "float"
-  ResourceCreatedResponse:
-    type: "object"
-    properties:
-      message:
-        type: "string"
-        example: "The resource has been successfully created"
   ErrorResponse:
     type: "object"
     properties:
       error:
         type: "string"
-        example: "missing_param"
+        enum: ["invalid_request"]
+        example: "invalid_request"
       message:
         type: "string"
         example: "param 'foo_bar' is missing"

--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -13,8 +13,8 @@ info:
     url: "https://opensource.org/licenses/MIT"
 host: "to-be-defined.io"
 tags:
-- name: "stop_points"
-  description: "Suggesting patches to improve stop point location"
+- name: "stop_point_patch"
+  description: "Suggest patches to improve stop point information"
 - name: "status"
   description: "Verify the API status"
 schemes:
@@ -23,9 +23,8 @@ paths:
   /nav-1/v1/stop_point_patches:
     post:
       tags:
-        - "stop_points"
-      summary: "Suggest a new location for a stop point"
-      description: "Description"
+        - "stop_point_patch"
+      summary: "Create a stop point patch"
       consumes:
         - "application/json"
       produces:
@@ -74,8 +73,8 @@ paths:
   /nav-1/v1/stop_point_patches/gps:
     post:
       tags:
-      - "stop_points"
-      summary: "Suggest a new location for a stop point using the given GPS coord / accuracy"
+      - "stop_point_patch"
+      summary: "Create a stop point patch using the given GPS coord / accuracy"
       consumes:
       - "application/json"
       produces:
@@ -123,10 +122,11 @@ paths:
       - api_key: []
   /status:
     get:
+      summary: "Check if the service is up and running"
       tags:
       - "status"
       produces:
-        - "application/json"
+      - "application/json"
       responses:
         200:
           description: "The API is reachable"
@@ -136,8 +136,6 @@ paths:
               message:
                 type: "string"
                 example: "The API is up and running !"
-      
-      
 securityDefinitions:
   api_key:
     type: "apiKey"

--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -5,8 +5,6 @@ info:
     resources.
   version: "0.1.0"
   title: "Hermod - the Crowd sourcing API"
-  contact:
-    email: "to-be-defined@navitia.io"
   license:
     name: "MIT"
     url: "https://opensource.org/licenses/MIT"
@@ -18,7 +16,7 @@ tags:
 schemes:
 - "https"
 paths:
-  /v1/stop_point_patches:
+  /v1/location_patches:
     post:
       tags:
         - "stop_point_patch"
@@ -36,6 +34,7 @@ paths:
             - source
             - stop_point
             - stop_point_current_location
+            - stop_point_patched_location
             - route
             properties:
               source:
@@ -59,11 +58,11 @@ paths:
             $ref: "#/definitions/Errors"
       security:
       - api_key: []
-  /v1/stop_point_patches/gps:
+  /v1/location_patches/from_user_location:
     post:
       tags:
       - "stop_point_patch"
-      summary: "Create a stop point patch using the given GPS coord / accuracy"
+      summary: "Create a stop point patch using the given end-user GPS coord / accuracy"
       consumes:
       - "application/json"
       produces:
@@ -77,7 +76,7 @@ paths:
             - source
             - stop_point
             - stop_point_current_location
-            - route_id
+            - route
             - gps
             properties:
               source:
@@ -86,9 +85,8 @@ paths:
                 $ref: "#/definitions/StopPoint"
               stop_point_current_location:
                 $ref: "#/definitions/Coord"
-              route_id:
-                type: "string"
-                description: "Route id"
+              route:
+                $ref: "#/definitions/Route"
               gps:
                 $ref: "#/definitions/Gps"
       responses:
@@ -124,15 +122,11 @@ securityDefinitions:
 definitions:
   Source:
     type: "object"
-    required: ["type", "instance_name"]
+    required: ["name"]
     properties:
-      type:
+      name:
         type: "string"
-        enum: ["nav_1", "nav_2"]
-        description: "The navitia version to use"
-      instance_name:
-        type: "string"
-        description: "Stop point name"
+        description: "The data source name"
   StopPoint:
     type: "object"
     required: ["id", "name"]
@@ -150,6 +144,9 @@ definitions:
       id:
         type: "string"
         description: "Route id"
+      name:
+        type: "string"
+        description: "Route name"
   Gps:
     type: "object"
     properties:
@@ -171,15 +168,13 @@ definitions:
         type: "number"
         format: "float"
   Errors:
-    type: "array"
-    title: "Errors"
-    items:
-      type: "object"
-      properties:
-        error:
+    properties:
+      error:
+        type: "string"
+        enum: ["invalid_params"]
+        example: "invalid_params"
+      messages:
+        type: "array"
+        items:
           type: "string"
-          enum: ["invalid_request"]
-          example: "invalid_request"
-        message:
-          type: "string"
-          example: "param 'foo_bar' is missing"
+          example: "invalid coordinates"


### PR DESCRIPTION
This is the first version of the api spec in swagger format.

### To test
Go to http://editor.swagger.io/ and paste the content of this file in the editor

### Some highlights:
- Routes are prefixed with the navitia version to ease the switch to navitia 2
- We decided to have 2 routes to suggest stop points patches (mainly to ease the consumer integration)
- There's a /status that just returns a HTTP 200 with a dummy object (may be improved in the near future) so it's fairly easy to probe the availability of this service
- Error responses will contains an error type (ex: missing_param) and a string describing the error. This is only to ease the understanding of the API when integrating it