### PR TITLE
Remove traefik on dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,50 +3,33 @@ Crowd sourcing API for Navitia
 
 ## Docker
 
-## For development env (with traefik)
-
-In this example, we suppose `hermod.localhost` should be your host
-
-### Configurations
-
-Run only this command with `root` user
-```
-echo -e "127.0.0.1\thermod.localhost" >> /etc/hosts
-```
-
-### Traefik
-
-Create network for traefik and run it (Be careful, port: 80 should be free)
-
-```
-docker network create traefik_proxy --driver bridge --attachable
-```
-
-```
-docker run --rm -d --name traefik --network traefik_proxy --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock containous/traefik:v1.3.0-rc2 --docker --docker.watch --docker.domain=localhost
-```
+## For development env
 
 ### Build & Run Hermod api
 
-This command will build `hermod_php:dev` image and run `composer install`
+If this the first time you are building this API:
+start the docker container used to generate local DNS entries:
+```
+docker pull zibok/docker-gen-hosts && docker run -d --restart=always -v /etc/hosts:/generated_hostfile -v /var/run/docker.sock:/var/run/docker.sock --name docker-gen-hosts zibok/docker-gen-hosts
+```
+
+*This docker image is responsible of updating your /etc/hosts file to create the hermod.local -> docker-container-ip-address resolution*
+
+Build the Hermod docker image and install dependencies:
 ```
 ./docker/build_dev.sh
 ```
 
-Now you can up hermod
+Start Hermod:
 ```
 docker-compose up -d
 ```
 
-To see logs remove `-d` option or use `docker logs ...` command
+Go to `http://hermod.local/v1/status`, the api should be up and running !
 
-Go to `http://hermod.localhost/v1/status`, the api should work
-
-When you finished
+When you are done:
 ```
 docker-compose down
-docker stop traefik
-docker network rm traefik_proxy
 ```
 
 ## For production env (with traefik)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,8 @@ services:
       - ./docker/nginx/conf.d:/etc/nginx/conf.d:ro
     networks:
       - hermod
-      - traefik_proxy
-    labels:
-      - "traefik.frontend.rule=Host:hermod.localhost"
-      - "traefik.docker.network=traefik_proxy"
-      - "traefik.port=80"
-      - "traefik.frontend.entryPoints=http"
+    environment:
+      - DOMAIN_NAME=hermod.local
 
   php-fpm:
     image: hermod_php:dev
@@ -29,8 +25,6 @@ services:
       - docker/config.env
     networks:
       - hermod
-    labels:
-      - "traefik.enable=false"
 
   database:
     image: postgres:9.6
@@ -40,11 +34,7 @@ services:
       - docker/config.env
     networks:
       - hermod
-    labels:
-      - "traefik.enable=false"
 
 networks:
   hermod:
     driver: bridge
-  traefik_proxy:
-    external: true


### PR DESCRIPTION
Traefik on dev was not really useful and added unnecessary setup time. Now just do
```
docker-compose up -d
```
And everything should be up