### PR TITLE
Equipment status post spec

### DIFF
--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -116,13 +116,13 @@ paths:
             type: "object"
             required:
             - source
-            - reported_by
+            - type
             - equipment
             - status
             properties:
               source:
                 $ref: "#/definitions/Source"
-              reported_by:
+              type:
                 type: string
                 enum: ["traveler", "employee"]
               equipment:
@@ -192,11 +192,15 @@ definitions:
         description: "Route name"
   Equipment:
     type: "object"
-    required: ["id"]
+    required: ["id", "type"]
     properties:
       id:
-        type: "string"
+        type: "integer"
         description: "Equipment id"
+      type:
+        type: "string"
+        description: "Equipment type"
+        enum: ["elevator"]
   Gps:
     type: "object"
     properties:
@@ -227,4 +231,4 @@ definitions:
         type: "array"
         items:
           type: "string"
-          example: "invalid coordinates"
+          example: "some input params are invalid"

--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -11,6 +11,8 @@ info:
 tags:
 - name: "location_patch"
   description: "Suggest patches to improve stop information"
+- name: "equipment_status"
+  description: "Report and retrieve status of various equipments"
 - name: "status"
   description: "Verify the API status"
 schemes:
@@ -98,6 +100,47 @@ paths:
             $ref: "#/definitions/Errors"
       security:
       - api_key: []
+  /v1/equipment_status:
+    post:
+      tags:
+      - "equipment_status"
+      summary: "Report the status of an equipment"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          schema:
+            type: "object"
+            required:
+            - source
+            - reported_by
+            - equipment
+            - status
+            properties:
+              source:
+                $ref: "#/definitions/Source"
+              reported_by:
+                type: string
+                enum: ["traveler", "employee"]
+              equipment:
+                $ref: "#/definitions/Equipment"
+              status:
+                type: string
+                enum: ["OK", "KO"]
+              gps:
+                $ref: "#/definitions/Gps"
+      responses:
+        201:
+          description: "Everything went fine"
+        400:
+          description: "Invalid request"
+          schema:
+            $ref: "#/definitions/Errors"
+      security:
+      - api_key: []
   /v1/status:
     get:
       summary: "Utility endpoint to check if the service is up and running"
@@ -147,6 +190,13 @@ definitions:
       name:
         type: "string"
         description: "Route name"
+  Equipment:
+    type: "object"
+    required: ["id"]
+    properties:
+      id:
+        type: "string"
+        description: "Equipment id"
   Gps:
     type: "object"
     properties:


### PR DESCRIPTION
First draft for the new POST /equipment_status API

Available at: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/rchoquet/Hermod/36f248d222ddceed1fe7cbdc49486efe9f31b8ea/swagger-spec.yaml

- as I gave a generic name for this API, we should maybe add a equipment_type, to know whether it's an elevator, escalator,...,  not sure though
- to stay consistent i also think renaming /equipment_status to /status_report could be better