### PR TITLE
Add version to status API + update composer install for release build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@ docker/postgres/data
 .gitignore
 .dockerignore
 junit.xml
+app/config/parameters.yml
+var/logs/*
+var/cache/*
+var/sessions/*

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -12,3 +12,4 @@ parameters:
 
     # Default value if env vars does not exist
     env(LOG_PATH): "%kernel.logs_dir%/%kernel.environment%.log"
+    version: dev

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,9 @@
         ],
         "post-update-cmd": [
             "@symfony-scripts"
+        ],
+        "build-parameters": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
         ]
     },
     "config": {
@@ -69,7 +72,10 @@
         "symfony-tests-dir": "tests",
         "symfony-assets-install": "copy",
         "incenteev-parameters": {
-            "file": "app/config/parameters.yml"
+            "file": "app/config/parameters.yml",
+            "env-map": {
+                "version": "VERSION"
+            }
         },
         "branch-alias": null
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "685258f432ff5281363fa048f333cd34",
+    "content-hash": "35059e1ac35f19a1c5d636fcda629450",
     "packages": [
         {
             "name": "behat/transliterator",

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -10,22 +10,5 @@ if [ ! -f 'docker/config.env' ]; then
     exit 66 # EX_NOINPUT
 fi
 
-cp app/config/parameters.yml.dist app/config/parameters.yml
-docker run --rm \
-    --user $(id -u) \
-    --volume /etc/passwd:/etc/passwd:ro \
-    --volume /etc/group:/etc/group:ro \
-    --volume ${HOME}/.composer/.config/composer:/composer:rw \
-    --volume ${HOME}/.ssh:$HOME/.ssh:ro \
-    --volume "${PWD}:/app" \
-    --workdir /app \
-    --env-file ./docker/config.env \
-    --env SYMFONY_ENV=prod \
-    --label "traefik.enable=false" \
-    composer:latest \
-    composer install --ignore-platform-reqs --no-interaction --prefer-dist --no-scripts --no-dev
-
-rm -rf var/cache/* var/logs/* var/sessions/*
-
-docker build --rm -t ${DOCKER_REGISTRY_HOST}/hermod_php:${VERSION} -f docker/php/Dockerfile .
+docker build --build-arg VERSION=${VERSION} --rm -t ${DOCKER_REGISTRY_HOST}/hermod_php:${VERSION} -f docker/php/Dockerfile .
 docker build --rm -t ${DOCKER_REGISTRY_HOST}/hermod_nginx:${VERSION} -f docker/nginx/Dockerfile .

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -2,6 +2,9 @@ FROM php:7.1-fpm
 
 WORKDIR /srv/hermod
 
+ENV SYMFONY_ENV prod
+ARG VERSION
+
 # Install pdo extension for Postgre
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     libpq-dev \
@@ -36,8 +39,26 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 RUN echo 'date.timezone = "UTC"' >> /usr/local/etc/php/php.ini
 RUN echo 'opcache.max_accelerated_files = 20000' >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
+# Install composer part
+RUN curl -sS https://getcomposer.org/installer | \
+    php -- --install-dir=/usr/bin/ --filename=composer
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+    git \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get autoremove -y
+
 COPY . /srv/hermod/
 COPY docker/php/www.conf  /usr/local/etc/php-fpm.d/www.conf
+
+# Run composer
+RUN export $(cat docker/config.env | xargs) \
+    && composer run-script --no-dev build-parameters \
+    && composer install --no-interaction --prefer-dist --no-scripts --no-dev
+
+# Uninstall composer part
+RUN rm -f /usr/bin/composer \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false git \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --home-dir /srv/hermod/ hermod
 RUN chown -R hermod:hermod /srv/hermod/

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -39,26 +39,21 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 RUN echo 'date.timezone = "UTC"' >> /usr/local/etc/php/php.ini
 RUN echo 'opcache.max_accelerated_files = 20000' >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
-# Install composer part
-RUN curl -sS https://getcomposer.org/installer | \
-    php -- --install-dir=/usr/bin/ --filename=composer
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-    git \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get autoremove -y
-
 COPY . /srv/hermod/
 COPY docker/php/www.conf  /usr/local/etc/php-fpm.d/www.conf
 
 # Run composer
-RUN export $(cat docker/config.env | xargs) \
+RUN curl -sS https://getcomposer.org/installer | \
+    php -- --install-dir=/usr/bin/ --filename=composer \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+    unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get autoremove -y \
+    && export $(cat docker/config.env | xargs) \
+    && composer install --no-interaction --prefer-dist --no-scripts --no-dev \
     && composer run-script --no-dev build-parameters \
-    && composer install --no-interaction --prefer-dist --no-scripts --no-dev
-
-# Uninstall composer part
-RUN rm -f /usr/bin/composer \
-    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false git \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false unzip \
+    && rm -f /usr/bin/composer
 
 RUN useradd --home-dir /srv/hermod/ hermod
 RUN chown -R hermod:hermod /srv/hermod/

--- a/src/AppBundle/Controller/v1/AppController.php
+++ b/src/AppBundle/Controller/v1/AppController.php
@@ -18,7 +18,8 @@ class AppController extends BaseController
     public function statusAction()
     {
         return new JsonResponse([
-            'status' => 'OK'
+            'status' => 'OK',
+            'version' => $this->getParameter('version')
         ]);
     }
 }

--- a/tests/AppBundle/Controller/v1/AppControllerTest.php
+++ b/tests/AppBundle/Controller/v1/AppControllerTest.php
@@ -12,5 +12,7 @@ class AppControllerTest extends ApiTestCase
         $data = $this->getBody($response);
         $this->assertArrayHasKey('status', $data);
         $this->assertEquals($data['status'], 'OK');
+        $this->assertArrayHasKey('version', $data);
+        $this->assertEquals($data['version'], 'dev');
     }
 }


### PR DESCRIPTION
#### What I did

I add the parameter version to the status API

#### How I did it

I set the property in the build step of the image (+ some refacto on composer install)

#### How to verify it

- Build a new image for hermod_php using docker/build.sh (see README.md of this project)
- Launch the docker for this image version (docker/docker-compose.prod.yml)
- Create / choose a user with ROLE_ROOT
- Call status API
- You should see in the version part, the tag use for this image
